### PR TITLE
Check for "skipped" outcome instead of empty string

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
 
     - name: Check Summary
       # write check output to job summary if check failed
-      if: ${{ steps.check.outcome != 'success' }}
+      if: ${{ steps.check.outcome != '' && steps.check.outcome != 'success' }}
       shell: bash
       run: |
         cat >${GITHUB_STEP_SUMMARY}<<EOF

--- a/action.yml
+++ b/action.yml
@@ -117,6 +117,7 @@ runs:
       shell: bash
       run: |
         cat >${GITHUB_STEP_SUMMARY}<<EOF
+        outcome was ${{ steps.check.outcome }}
         ${{ steps.check.outputs.output }}
         EOF
         exit 1

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ runs:
     - name: DNSControl
       id: dnscontrol
       # execute only if check was ok or skipped
-      if: ${{ inputs.check == false || (inputs.check == 'true' && steps.check.outcome == 'success') }}
+      if: ${{ (steps.check.outcome != 'skipped' && steps.check.outcome == 'success' ) || steps.check.outcome == 'skipped' }}
       continue-on-error: true
       shell: bash
       env:
@@ -154,7 +154,7 @@ runs:
     - name: Attach Results as PR comment
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       # execute if user set post_pr_comment, this is a PR event, AND dnscontrol job ran
-      if: ${{ inputs.post_pr_comment && github.event.pull_request.number != '' && steps.dnscontrol.outcome != '' }}
+      if: ${{ inputs.post_pr_comment && github.event.pull_request.number != '' && steps.dnscontrol.outcome != 'skipped' }}
       with:
         comment-tag: dnscontrol_preview_push_external
         message: |

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
 
     - name: Check Summary
       # write check output to job summary if check failed
-      if: ${{ steps.check.outcome != '' && steps.check.outcome != 'success' }}
+      if: ${{ steps.check.outcome != 'skipped' && steps.check.outcome != 'success' }}
       shell: bash
       run: |
         cat >${GITHUB_STEP_SUMMARY}<<EOF
@@ -143,7 +143,7 @@ runs:
     - name: Write output file
       id: write_file
       # execute if user specified an output file AND dnscontrol job ran
-      if: ${{ inputs.output_file != '' && steps.dnscontrol.outcome != '' }}
+      if: ${{ inputs.output_file != '' && steps.dnscontrol.outcome != 'skipped' }}
       shell: bash
       env:
         OUTPUT_FILE: ${{ inputs.output_file }}
@@ -170,7 +170,7 @@ runs:
     - name: Job Summary
       id: job_summary
       # execute if user set post_summary AND dnscontrol job ran
-      if: ${{ inputs.post_summary == 'true' && steps.dnscontrol.outcome != '' }}
+      if: ${{ inputs.post_summary == 'true' && steps.dnscontrol.outcome != 'skipped' }}
       shell: bash
       run: |
         cat >${GITHUB_STEP_SUMMARY}<<EOF


### PR DESCRIPTION
Preflight check is supposed to be optional.

Checking previous step outcome was buggy. This fixes that by looking for "skipped" when a step was ... skipped.

fixes #29