### PR TITLE
better log reading experience

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,7 @@ runs:
       if: ${{ inputs.version == 'latest' }}
       shell: bash
       run: |
+        echo "Resolve download URL for latest"
         CURL='curl -H user-agent:stackexchange-dnscontrol-action -fsS --retry 5 --retry-max-time 30'
         echo "CURL=$CURL" >>"$GITHUB_ENV"
         URL=$(\
@@ -74,16 +75,17 @@ runs:
       if: ${{ inputs.version != 'latest' }}
       shell: bash
       run: |
+        echo "Resolve download URL for ${{ inputs.version }}"
         URL=$(\
           $CURL -L https://api.github.com/repos/StackExchange/dnscontrol/releases \
           | jq -r '.[] | select(.tag_name == "${{ inputs.version }}") | .assets[] | select(.name? | match("dnscontrol_*.*.*_linux_amd64.tar.gz$")) | .browser_download_url' \
         )
         echo "URL=$URL" >>"$GITHUB_ENV"
 
-    - name: Install DNSControl
+    - name: Download DNSControl ${{ inputs.version }}
       shell: bash
       run: |
-        echo "Downloading DNSControl ${{ inputs.version }}"
+        echo "Download DNSControl ${{ inputs.version }}"
         $CURL -L "${URL}" \
           | tar -xvzf - dnscontrol
         DNSCONTROL=$(readlink -f dnscontrol)
@@ -98,6 +100,7 @@ runs:
       env:
         NO_COLOR: 'true'
       run: |
+          echo "DNSControl check"
           set +e
           DNSCONTROL_CMD=$($DNSCONTROL check --config ${{ inputs.dnsconfig_file }})
           err=$?
@@ -116,6 +119,7 @@ runs:
       if: ${{ steps.check.outcome != 'skipped' && steps.check.outcome != 'success' }}
       shell: bash
       run: |
+        echo "Check Summary"
         cat >${GITHUB_STEP_SUMMARY}<<EOF
         outcome was ${{ steps.check.outcome }}
         ${{ steps.check.outputs.output }}
@@ -131,6 +135,7 @@ runs:
       env:
         NO_COLOR: 'true'
       run: |
+          echo "DNSControl"
           export DNSCONTROL_CMD=$($DNSCONTROL ${{ inputs.cmdargs }} --config ${{ inputs.dnsconfig_file }} --creds ${{ inputs.creds_file }})
           DELIMITER="DNSCONTROL-$RANDOM"
           {
@@ -148,6 +153,7 @@ runs:
       env:
         OUTPUT_FILE: ${{ inputs.output_file }}
       run: |
+        echo "Write output file"
         echo "${{ steps.dnscontrol.outputs.output }}" > $OUTPUT_FILE
         echo "output_file=$OUTPUT_FILE" >>"$GITHUB_OUTPUT"
 
@@ -173,6 +179,7 @@ runs:
       if: ${{ inputs.post_summary == 'true' && steps.dnscontrol.outcome != 'skipped' }}
       shell: bash
       run: |
+        echo "Job Summary"
         cat >${GITHUB_STEP_SUMMARY}<<EOF
         ${{ steps.dnscontrol.outputs.output }}
         EOF

--- a/action.yml
+++ b/action.yml
@@ -136,14 +136,16 @@ runs:
         NO_COLOR: 'true'
       run: |
           echo "DNSControl"
-          export DNSCONTROL_CMD=$($DNSCONTROL ${{ inputs.cmdargs }} --config ${{ inputs.dnsconfig_file }} --creds ${{ inputs.creds_file }})
+          set +e
+          DNSCONTROL_CMD=$($DNSCONTROL ${{ inputs.cmdargs }} --config ${{ inputs.dnsconfig_file }} --creds ${{ inputs.creds_file }})
+          err=$?
           DELIMITER="DNSCONTROL-$RANDOM"
           {
             echo "output<<$DELIMITER"
             echo "$DNSCONTROL_CMD"
             echo "$DELIMITER"
           } >>"$GITHUB_OUTPUT"
-          echo $DNSCONTROL_CMD
+          exit $err
 
     - name: Write output file
       id: write_file


### PR DESCRIPTION
* echo the step name for every `run` 
* skip dumping main dnscontrol execution into logs for better readability 

fixes #32 