### PR TITLE
fix linter setup

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -37,7 +37,7 @@ jobs:
             $CURL -L https://api.github.com/repos/koalaman/shellcheck/releases/latest \
             | jq -r '.tag_name'\
           )
-          $CURL -L "${URL}" | tar -C $SHELLCHECK_PREFIX -xvzf - shellcheck-$VERSION/shellcheck
+          $CURL -L "${URL}" | xzcat | tar -C $SHELLCHECK_PREFIX -xvf - shellcheck-$VERSION/shellcheck
           $SHELLCHECK_PREFIX/shellcheck-$VERSION/shellcheck version
 
           echo "$SHELLCHECK_PREFIX/shellcheck-$VERSION/shellcheck" >> "$GITHUB_PATH"


### PR DESCRIPTION
shellcheck archive is xz compressed